### PR TITLE
fix for indirect dev deps

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -311,9 +311,12 @@ runs:
         }
 
         failures <- x$get_solution()$failures
-        failed_refs <- failures[1, "failure_down"][[1]]
+        failed_refs <- unique(unlist(failures[, "failure_down"]))
         cli::cli_alert_warning("Failed to resolve dependencies. Failed refs: {.pkg {failed_refs}}.")
+        cli::cli_text("Error:")
         cat(format(failures))
+        cat("\n")
+        cli::cli_text("End of error")
 
         failure_message <- failures$failure_message
         if (identical(failure_message, failures_message_prev)) {
@@ -326,7 +329,7 @@ runs:
           pkg <- pkgdepends::parse_pkg_ref(failed_ref)$package
           pkg_ref <- find_ref(pkg, lookup_refs)
           if (length(pkg_ref) == 0) {
-            cli::cli_alert_danger("Package {.pkg {pkg}} not found in the {.code {lookup_refs}} list. Exiting.")
+            cli::cli_alert_danger("Package {.pkg {pkg}} not found in the {.code lookup_refs} list: {.val {lookup_refs}}. Exiting.")
             break()
           }
           cli::cli_alert_info("Adding package {.pkg {pkg}} (ref: {.val {pkg_ref$ref}}) to the {.field Config/Needs/DepsDev} field.")
@@ -335,6 +338,7 @@ runs:
         }
 
         cli::cli_alert_info("Trying to resolve dependencies again.")
+        cli::cli_text("---")
         x <- new_pkg_deps(path)
       }
 


### PR DESCRIPTION
- fix for indirect dev deps
When debugging the error in `teal.modules.clinical` we have the following:
```
r$> failures[c(1, 217), "failure_down"]
[[1]]
[1] "teal"                     "insightsengineering/teal"

[[2]]
[1] "teal.data"     "teal.slice"    "teal.reporter"
```
We must use the whole `failures` data.frame - not only the very first row.
- enhanced prints