### PR TITLE
Override repositories used by `pak`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -351,8 +351,8 @@ runs:
       cat > ${HOME}/.Rprofile <<EOF
       options(
         repos = c(
-          RSPM = "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
-          CRAN = "https://packagemanager.posit.co/cran/__linux__/jammy/latest"
+          RSPM = "https://packagemanager.posit.co/cran/__linux__/noble/latest",
+          CRAN = "https://packagemanager.posit.co/cran/__linux__/noble/latest"
         )
       )
       EOF

--- a/action.yaml
+++ b/action.yaml
@@ -348,11 +348,12 @@ runs:
 
   - name: Set repositories
     run: |
+      OS_CODENAME=$(lsb_release --codename --short)
       cat > ${HOME}/.Rprofile <<EOF
       options(
         repos = c(
-          RSPM = "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
-          CRAN = "https://packagemanager.posit.co/cran/__linux__/jammy/latest"
+          RSPM = "https://packagemanager.posit.co/cran/__linux__/${OS_CODENAME}/latest",
+          CRAN = "https://packagemanager.posit.co/cran/__linux__/${OS_CODENAME}/latest"
         )
       )
       EOF

--- a/action.yaml
+++ b/action.yaml
@@ -348,7 +348,7 @@ runs:
 
   - name: Set repositories
     run: |
-      OS_CODENAME=$(lsb_release --codename --short)
+      OS_CODENAME=$(lsb_release --codename --short | tail)
       cat > ${HOME}/.Rprofile <<EOF
       options(
         repos = c(

--- a/action.yaml
+++ b/action.yaml
@@ -346,6 +346,20 @@ runs:
     shell: bash
     run: rm utils.R
 
+  - name: Set repositories
+    run: |
+      cat > ${HOME}/.Rprofile <<EOF
+      options(
+        repos = c(
+          RSPM = "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
+          CRAN = "https://packagemanager.posit.co/cran/__linux__/jammy/latest"
+        )
+      )
+      EOF
+      echo "Repositories written to ${HOME}/.Rprofile:"
+      cat ${HOME}/.Rprofile
+    shell: bash
+
   - uses: r-lib/actions/setup-r-dependencies@v2
     if: ${{ inputs.skip-install == 'false' }}
     with:

--- a/action.yaml
+++ b/action.yaml
@@ -351,8 +351,8 @@ runs:
       cat > ${HOME}/.Rprofile <<EOF
       options(
         repos = c(
-          RSPM = "https://packagemanager.posit.co/cran/__linux__/noble/latest",
-          CRAN = "https://packagemanager.posit.co/cran/__linux__/noble/latest"
+          RSPM = "https://packagemanager.posit.co/cran/__linux__/focal/latest",
+          CRAN = "https://packagemanager.posit.co/cran/__linux__/focal/latest"
         )
       )
       EOF

--- a/action.yaml
+++ b/action.yaml
@@ -351,8 +351,8 @@ runs:
       cat > ${HOME}/.Rprofile <<EOF
       options(
         repos = c(
-          RSPM = "https://packagemanager.posit.co/cran/__linux__/focal/latest",
-          CRAN = "https://packagemanager.posit.co/cran/__linux__/focal/latest"
+          RSPM = "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
+          CRAN = "https://packagemanager.posit.co/cran/__linux__/jammy/latest"
         )
       )
       EOF


### PR DESCRIPTION
Without overriding these repositories, we have the following output of **the second** `Show lockfile` step of `setup-r-dependencies` (`cli` shown as an example) ([example job](https://github.com/walkowif/teal/actions/runs/10828991221/job/30045569557)):
```json
"metadata": {
  "RemoteType": "standard",

  "RemotePkgRef": "cli",
  "RemoteRef": "cli",
  "RemoteRepos": "https://cloud.r-project.org/",
  "RemotePkgPlatform": "source",
  "RemoteSha": "3.6.3"
},
"sources": ["https://cloud.r-project.org/src/contrib/cli_3.6.3.tar.gz", "https://cloud.r-project.org/src/contrib/Archive/cli/cli_3.6.3.tar.gz"],
"target": "src/contrib/cli_3.6.3.tar.gz",
"platform": "source",
```

When we override the repositories using the method from this PR, we have the following output of **the second** `Show lockfile` step of `setup-r-dependencies` (`cli` shown as an example) ([example job](https://github.com/walkowif/teal/actions/runs/10829260720/job/30046426216)):
```json
"metadata": {
    "RemoteType": "standard",
    "RemotePkgRef": "cli",
    "RemoteRef": "cli",
    "RemoteRepos": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
    "RemotePkgPlatform": "x86_64-pc-linux-gnu-ubuntu-22.04",
    "RemoteSha": "3.6.3"
  },
"sources": ["https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/cli_3.6.3.tar.gz"],
"target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/cli_3.6.3.tar.gz",
"platform": "x86_64-pc-linux-gnu-ubuntu-22.04",
```