### PR TITLE
Copy and restore DESCRIPTION

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -85,6 +85,7 @@ runs:
     shell: bash
 
   - name: Copy DESCRIPTION
+    if: ${{ inputs.restore-description == 'true' }}
     run: |
       echo "::group::Copy DESCRIPTION"
       temp_desc=$(mktemp)


### PR DESCRIPTION
Other steps in the workflow might also modify or might want to use original (unmodified by `setup-r-dependencies`) `DESCRIPTION`. Therefore the original `DESCRIPTION` is copied to a temporary location and at the end of the action is optionally restored from the temporary location.