### PR TITLE
A new `install-quarto` param

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ Insights Engineering
 
     _Default_: `""`
 
+* `install-quarto`:
+
+    _Description_: Passed to `r-lib/actions/setup-r-dependencies`.
+
+    _Required_: `false`
+
+    _Default_: `auto`
+
 * `needs`:
 
     _Description_: Passed to `r-lib/actions/setup-r-dependencies`. The value will be amended by `DepsBranch` and `DepsDev` values.

--- a/action.yaml
+++ b/action.yaml
@@ -111,6 +111,7 @@ runs:
         any::desc
         any::pkgcache
       install-pandoc: false
+      install-quarto: false
 
   - name: Set repositories
     run: |

--- a/action.yaml
+++ b/action.yaml
@@ -27,6 +27,10 @@ inputs:
     description: Passed to `r-lib/actions/setup-r-dependencies`.
     required: false
     default: ""
+  install-quarto:
+    description: Passed to `r-lib/actions/setup-r-dependencies`.
+    required: false
+    default: "auto"
   needs:
     description: |
       Passed to `r-lib/actions/setup-r-dependencies`.
@@ -395,6 +399,7 @@ runs:
         DepsBranch
         DepsDev
       dependencies: ${{ inputs.dependencies }}
+      install-quarto: ${{ inputs.install-quarto }}
 
   - name: Restore DESCRIPTION
     if: ${{ inputs.restore-description == 'true' }}


### PR DESCRIPTION
Adds a new parameter to the action and pass it down into the `r-lib/actions/setup-r-dependencies@v2`

This is needed as install quarto does not work for all machines in rhub workflows