### PR TITLE
add a new parameter `cache-version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ Insights Engineering
 
     _Default_: `auto`
 
+* `cache-version`:
+
+    _Description_: Passed to `r-lib/actions/setup-r-dependencies`.
+
+    _Required_: `false`
+
+    _Default_: `1`
+
 * `needs`:
 
     _Description_: Passed to `r-lib/actions/setup-r-dependencies`. The value will be amended by `DepsBranch` and `DepsDev` values.

--- a/action.yaml
+++ b/action.yaml
@@ -121,11 +121,14 @@ runs:
     run: |
       # Set repositories
       cat > ${HOME}/.Rprofile <<EOF
-      repository_list <- unlist(strsplit(
+      repository_list <- trimws(unlist(strsplit(
         "${{ inputs.repository-list }}", split=","
-      ))
+      )))
       options(repos = unique(c(vapply(repository_list, pkgcache::repo_resolve, character(1)), getOption("repos"))))
       EOF
+      echo "::group::Show .Rprofile"
+      cat ${HOME}/.Rprofile
+      echo "::endgroup::"
     shell: bash
 
   - name: Define utils

--- a/action.yaml
+++ b/action.yaml
@@ -31,6 +31,10 @@ inputs:
     description: Passed to `r-lib/actions/setup-r-dependencies`.
     required: false
     default: "auto"
+  cache-version:
+    description: Passed to `r-lib/actions/setup-r-dependencies`.
+    required: true
+    default: 1
   needs:
     description: |
       Passed to `r-lib/actions/setup-r-dependencies`.
@@ -401,6 +405,7 @@ runs:
         DepsDev
       dependencies: ${{ inputs.dependencies }}
       install-quarto: ${{ inputs.install-quarto }}
+      cache-version: ${{ inputs.cache-version }}
 
   - name: Restore DESCRIPTION
     if: ${{ inputs.restore-description == 'true' }}


### PR DESCRIPTION
Add a new parameter `cache-version`.
This would be useful for TLG-Catalog where we want to have a separate cache for dev and stable