### PR TITLE
remove parameter `github-token`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,6 @@ Composite
 Insights Engineering
 
 ## Inputs
-* `github-token`:
-
-  _Description_: Token with permissions to clone repositories with dependencies.
-
-  _Required_: `false`
-
-  _Default_: `""`
-
 * `repository-path`:
 
   _Description_: Directory where the R package is located relative to the calling GitHub workflow workspace.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This logic requires additional input of package references to check against. Ple
 
 The implementation relies on the `pkgdepends` package and it is temporarily changing the `DESCRIPTION` file by adding new `Config/Needs/` fields. Then `r-lib/actions/setup-r-dependencies` is called with the `needs` parameter.
 
+For private repositories, run the action with `GITHUB_PAT` environment variable set to GitHub token. This is handled by `pak` (via `gitcreds` - see the [documentation](https://gitcreds.r-lib.org/reference/gitcreds_get.html)).
+
 ## Action type
 Composite
 

--- a/action.yaml
+++ b/action.yaml
@@ -4,10 +4,6 @@ author: Insights Engineering
 description: GitHub Action to install R package dependencies
 
 inputs:
-  github-token:
-    description: GitHub token.
-    required: false
-    default: ""
   repository-path:
     description: Directory where the R package is located relative to the calling GitHub workflow workspace.
     required: false


### PR DESCRIPTION
- remove not used parameter `github-token`
- this means a requirement for `GITHUB_PAT` env var on call