### PR TITLE
Provide default to get_fields

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -225,7 +225,7 @@ runs:
         d$has_fields(field) && !nzchar(d$get_field(field, ""))
       }
       
-      get_parsed_input <- function(d, field) {
+      desc_get_field_vec <- function(d, field) {
          parse_input(d$get_field(field, ""))
       }
       
@@ -403,7 +403,7 @@ runs:
           }
 
           # skip if already there
-          if (pkg_ref$ref %in% get_parsed_input(d, "Config/Needs/DepsDev")) {
+          if (pkg_ref$ref %in% desc_get_field_vec(d, "Config/Needs/DepsDev")) {
             cli::cli_alert_info("Reference for package {.pkg {pkg}} already exists in the {.field Config/Needs/DepsDev} field. Skipping.")
             next()
           }
@@ -411,8 +411,8 @@ runs:
           # skip if already in `DepsBranch`
           # this is to avoid duplicates - `Deps Branch` takes precedence over `DepsDev`
           if (
-            (!identical(get_parsed_input(d, "Config/Needs/DepsBranch"), "")) &&
-            (pkg %in% vapply(get_parsed_input(d, "Config/Needs/DepsBranch"), function(x) {if (x == "") { character(1L)} else {pkgdepends::parse_pkg_ref(x)$package}}, character(1)))
+            (!identical(desc_get_field_vec(d, "Config/Needs/DepsBranch"), "")) &&
+            (pkg %in% vapply(desc_get_field_vec(d, "Config/Needs/DepsBranch"), function(x) {if (x == "") { character(1L)} else {pkgdepends::parse_pkg_ref(x)$package}}, character(1)))
           ) {
             cli::cli_alert_info("A reference for package {.pkg {pkg}} already exists in the {.field Config/Needs/DepsBranch} field. Skipping.")
             next()

--- a/action.yaml
+++ b/action.yaml
@@ -162,7 +162,7 @@ runs:
         d$set_list(key, new_values)
       }
       desc_field_clear_if_empty <- function(d, key) {
-        if (d$has_fields(key) && d$get_field(key) == "") {
+        if (d$has_fields(key) && d$get_field(key, "") == "") {
           d$del(key)
         }
       }
@@ -394,7 +394,7 @@ runs:
           }
 
           # skip if already there
-          if (pkg_ref$ref %in% d$get_field("Config/Needs/DepsDev")) {
+          if (pkg_ref$ref %in% d$get_field("Config/Needs/DepsDev", ""))) {
             cli::cli_alert_info("Reference for package {.pkg {pkg}} already exists in the {.field Config/Needs/DepsDev} field. Skipping.")
             next()
           }
@@ -402,8 +402,8 @@ runs:
           # skip if already in `DepsBranch`
           # this is to avoid duplicates - `Deps Branch` takes precedence over `DepsDev`
           if (
-            (!identical(d$get_field("Config/Needs/DepsBranch"), "")) &&
-            (pkg %in% vapply(d$get_field("Config/Needs/DepsBranch"), function(x) pkgdepends::parse_pkg_ref(x)$package, character(1)))
+            (!identical(d$get_field("Config/Needs/DepsBranch", ""), "")) &&
+            (pkg %in% vapply(d$get_field("Config/Needs/DepsBranch", ""), function(x) pkgdepends::parse_pkg_ref(x)$package, character(1)))
           ) {
             cli::cli_alert_info("A reference for package {.pkg {pkg}} already exists in the {.field Config/Needs/DepsBranch} field. Skipping.")
             next()

--- a/action.yaml
+++ b/action.yaml
@@ -162,7 +162,7 @@ runs:
         d$set_list(key, new_values)
       }
       desc_field_clear_if_empty <- function(d, key) {
-        if (empty_field(d, key)) {
+        if (desc_empty_field(d, key)) {
           d$del(key)
         }
       }
@@ -221,7 +221,7 @@ runs:
         trimws(strsplit(x = gsub("\n", ",", input), split = ",")[[1]])
       }
       
-      empty_field <- function(d, field) {
+      desc_empty_field <- function(d, field) {
         d$has_fields(field) && !nzchar(d$get_field(field, ""))
       }
       

--- a/action.yaml
+++ b/action.yaml
@@ -156,13 +156,13 @@ runs:
       cat("::group::Define utils\n")
       desc_field_append <- function(d, key, value) {
         old_values <- d$get_field(key)
-        old_values_v <- trimws(strsplit(x = old_values, split = ",")[[1]])
+        old_values_v <- parse_input(old_values)
         new_values_v <- unique(c(old_values_v, value))
         new_values <- paste(new_values_v, collapse = ", ")
         d$set_list(key, new_values)
       }
       desc_field_clear_if_empty <- function(d, key) {
-        if (d$has_fields(key) && d$get_field(key) == "") {
+        if (empty_field(d, key)) {
           d$del(key)
         }
       }
@@ -220,6 +220,15 @@ runs:
       parse_input <- function(input) {
         trimws(strsplit(x = gsub("\n", ",", input), split = ",")[[1]])
       }
+      
+      empty_field <- function(d, field) {
+        d$has_fields(field) && !nzchar(d$get_field(field, ""))
+      }
+      
+      get_parsed_input <- function(d, field) {
+         parse_input(d$get_field(field, ""))
+      }
+      
       log_vars <- function(...) {
         args <- list(...)
         arg_names <- substitute(...())
@@ -394,7 +403,7 @@ runs:
           }
 
           # skip if already there
-          if (pkg_ref$ref %in% d$get_field("Config/Needs/DepsDev", ""))) {
+          if (pkg_ref$ref %in% get_parsed_input(d, "Config/Needs/DepsDev")) {
             cli::cli_alert_info("Reference for package {.pkg {pkg}} already exists in the {.field Config/Needs/DepsDev} field. Skipping.")
             next()
           }
@@ -402,8 +411,8 @@ runs:
           # skip if already in `DepsBranch`
           # this is to avoid duplicates - `Deps Branch` takes precedence over `DepsDev`
           if (
-            (!identical(d$get_field("Config/Needs/DepsBranch", ""), "")) &&
-            (pkg %in% vapply(d$get_field("Config/Needs/DepsBranch", ""), function(x) pkgdepends::parse_pkg_ref(x)$package, character(1)))
+            (!identical(get_parsed_input(d, "Config/Needs/DepsBranch"), "")) &&
+            (pkg %in% vapply(get_parsed_input(d, "Config/Needs/DepsBranch"), function(x) {if (x == "") { character(1L)} else {pkgdepends::parse_pkg_ref(x)$package}}, character(1)))
           ) {
             cli::cli_alert_info("A reference for package {.pkg {pkg}} already exists in the {.field Config/Needs/DepsBranch} field. Skipping.")
             next()

--- a/action.yaml
+++ b/action.yaml
@@ -162,7 +162,7 @@ runs:
         d$set_list(key, new_values)
       }
       desc_field_clear_if_empty <- function(d, key) {
-        if (d$has_fields(key) && d$get_field(key, "") == "") {
+        if (d$has_fields(key) && d$get_field(key) == "") {
           d$del(key)
         }
       }


### PR DESCRIPTION
This patch was proposed by Pawel to fix issues like https://github.com/insightsengineering/teal/actions/runs/11794622576/job/32853793903?pr=1406 and https://github.com/insightsengineering/teal/actions/runs/11794595252/job/32852528908?pr=1357 where the message is:

```
Modify DESCRIPTION file (development)
  ℹ Loading metadata database
  ✔ Loading metadata database ... done
  
  ! Failed to resolve dependencies.
  Error:
  * local::teal/:
    * Can't install dependency teal.data (>= 0.6.0.9017) (>= 0.5.1.9009) (>= 0.5.0.9015) (>= 0.3.1.9004)
    * Can't install dependency teal.slice (>= 0.5.1.9009) (>= 0.5.0.9015) (>= 0.3.1.9004)
    * Can't install dependency teal.code (>= 0.5.0.9015) (>= 0.3.1.9004)
    * Can't install dependency teal.reporter (>= 0.3.1.9004)
  End of error
  Failed refs: teal.data, teal.slice, teal.code, and teal.reporter.
  Error in val %||% default : Field 'Config/Needs/DepsBranch' not found
  Calls: <Anonymous> -> idesc_get_field -> %||%
  Execution halted
```

Simple reproducible code:

```
desc2 <- desc::description$new(file = system.file("DESCRIPTION",
                                              package = "desc"))
desc2$get_field("whatever")
## Error in val %||% default : Field 'whatever' not found
```

I also added a default on line 165 not originally proposed but I think could avoid this problem in other circumstances.

Not tested (yet) as I'm editing directly from github.